### PR TITLE
Feature: Option to Prevent Overwriting Slug

### DIFF
--- a/lib/sequelize-slugify.js
+++ b/lib/sequelize-slugify.js
@@ -32,7 +32,10 @@ SequelizeSlugify.prototype.slugifyModel = function(Model, slugOptions) {
         var slugValue = instance.slug;
 
         // if we dont have a slug yet or one of its fields have changed build a new slug
-        if(!slugValue || changed) {
+        if(slugValue && slugOptions.overwrite === false) {
+            instance.slug = slugValue;
+            return next(null, instance);
+        } else if (!slugValue || changed) {
             slugValue = slugifyFields(instance, slugOptions);
         } else {
             instance.slug = slugValue;


### PR DESCRIPTION
Adds option to `slugOptions`, preventing changed slugs from overwriting existing slugs, when `overwrite` is `false`.

Example:
```
SequalizeSlugify.slugifyModel(Post, {
	source: ['title'],
	overwrite: false
});
```