### PR TITLE
Add ability to draw from specified list of fields when building suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ SequelizeSlugify.slugifyModel(User, {
 Avaliable Options
 
 - `source` - (Required) Array of field names in the model to build the slug from
+- `suffixSource` - (Optional) Array of field names in the model to use as the source for additional suffixes to make the slug unique (before defaulting to adding numbers to the end of the slug).
 - `overwrite` = (Default TRUE) Change the slug if the source fields change once the slug has already been built
 
-## Usage Example
+## Usage Examples
+
+### Basic Usage
 
 ```javascript
 
@@ -64,6 +67,39 @@ module.exports = function(sequelize, DataTypes) {
 
     SequelizeSlugify.slugifyModel(User, {
         source: ['givenName', 'familyName']
+    });
+
+    return User;
+};
+
+```
+
+### Suffix Sources
+
+```javascript
+
+var SequelizeSlugify = require('sequelize-slugify');
+
+module.exports = function(sequelize, DataTypes) {
+    var Movie = sequelize.define('Movie', {
+            slug: {
+                type: DataTypes.STRING,
+                unique: true
+            },
+            title: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                unique: true
+            },
+            year: {
+                type: DataTypes.INTEGER,
+                allowNull: false
+            }
+        });
+
+    SequelizeSlugify.slugifyModel(Movie, {
+        source: ['title'],
+        suffixSource: ['year']
     });
 
     return User;

--- a/lib/sequelize-slugify.js
+++ b/lib/sequelize-slugify.js
@@ -7,22 +7,88 @@
 
 var slug = require('slug');
 var _ = require('lodash');
+var Promise = require('bluebird');
 
-var SequelizeSlugify = function() {};
+var SequelizeSlugify = function () {};
 
-SequelizeSlugify.prototype.slugifyModel = function(Model, slugOptions) {
-
+SequelizeSlugify.prototype.slugifyModel = function (Model, slugOptions) {
     // takes the array of source fields from the model instance and builds the slug
-    var slugifyFields = function (instance, slugOptions){
-        var slugParts = _.map(slugOptions.source, function(slugSourceField) {
+    var slugifyFields = function (instance, sourceFields) {
+        var slugParts = _.map(sourceFields, function (slugSourceField) {
             return instance[slugSourceField];
         });
-        return slug(slugParts.join(' '), {lower: true});
+
+        return slug(slugParts.join(' '), { lower: true });
+    };
+
+    /**
+     * Checks whether or not the slug is already in use.
+     *
+     * @param slug The slug to check for uniqueness.
+     * @return True if the slug is unique, false otherwise.
+     */
+    var checkSlug = function (slug) {
+        return Model.find({
+            where: {
+                slug: slug
+            }
+        }).then(function (model) {
+            return model === null;
+        });
+    };
+
+    /**
+     * Adds on additional suffixes based on the specified suffix fields.
+     *
+     * @param instance The model instance to use.
+     * @param sourceFields An array of source fields to use to generate the base slug.
+     * @param suffixFields An array of suffix fields to use to generate the additional slug suffixes.
+     * @return A promise that resolves to a slug once a unique one is found or all of the suffix fields have been exhausted. Returns null if no suffix fields are provided.
+     */
+    var addSourceSuffix = function (instance, sourceFields, suffixFields) {
+        return (function suffixHelper(instance, sourceFields, suffixFields, suffixCount) {
+            if (!suffixFields || !Array.isArray(suffixFields)) {
+                return Promise.resolve(null);
+            }
+
+            if (suffixCount > suffixFields.length) {
+                return Promise.resolve(slugifyFields(instance, slugOptions.source.concat(suffixFields.slice(0))));
+            }
+
+            var slug = slugifyFields(instance, slugOptions.source.concat(suffixFields.slice(0, suffixCount)));
+
+            return checkSlug(slug).then(function (isUnique) {
+                if (isUnique) {
+                    return slug;
+                }
+
+                return suffixHelper(instance, sourceFields, suffixFields, suffixCount + 1);
+            });
+        })(instance, sourceFields, suffixFields, 1);
+    };
+
+    /**
+     * Adds on a numeric suffix (i.e., "-1") to the provided slug.
+     *
+     * @param slug The slug to add the numeric suffix onto.
+     * @return A promise that resolves to a slug with the first numeric prefix that makes the slug unique.
+     */
+    var addNumericSuffix = function (slugValue) {
+        return (function suffixHelper(slug, count) {
+            var suffixedSlug = slug + '-' + count;
+
+            return checkSlug(suffixedSlug).then(function (isUnique) {
+                if (isUnique) {
+                    return suffixedSlug;
+                }
+
+                return suffixHelper(slug, count++);
+            });
+        })(slugValue, 1);
     };
 
     // callback that performs the slugification on the create/update callbacks
-    var handleSlugify = function(instance, options, next) {
-
+    var handleSlugify = function (instance, options, next) {
         // we overwrite slug value on source field changes by default
         if (typeof slugOptions.overwrite === 'undefined') {
             slugOptions.overwrite = true;
@@ -36,37 +102,47 @@ SequelizeSlugify.prototype.slugifyModel = function(Model, slugOptions) {
         // current slug value
         var slugValue = instance.slug;
 
-        // if we had no slug OR our slug changed and overwrite options is true
-        // build a new slug
+        // if we had no slug OR our slug changed and overwrite options is true build a new slug
         if (!slugValue || (slugOptions.overwrite && changed)) {
-            slugValue = slugifyFields(instance, slugOptions);
+            slugValue = slugifyFields(instance, slugOptions.source);
         } else {
             instance.slug = slugValue;
+
             return next(null, instance);
         }
 
-        // checks to make sure this slug is not already used
-        // iterates through -1 -2 suffixes until it finds an unused slug
-        Model.find({ where: { slug: slugValue } }).then( function(found) {
-            if (found === null) {
-                instance.slug = slugValue;
-                return next(null, instance);
-            } else {
-                var count = 1;
-                slugValue += '-';
-                (function recursiveFindUniqueSlug() {
-                    Model.find({ where: { slug: slugValue + count } })
-                        .then( function(found) {
-                            if (found === null) {
-                                instance.slug = slugValue + count;
-                                return next(null, instance);
-                            } else {
-                                count++;
-                                recursiveFindUniqueSlug();
-                            }
-                        });
-                })();
+        // determine if the slug is unique
+        return checkSlug(slugValue).then(function (isUnique) {
+            // go ahead and return the unique slug
+            if (isUnique) {
+                return slugValue;
             }
+
+            // add on suffixes from the provided source suffixes
+            return addSourceSuffix(instance, slugOptions.source, slugOptions.suffixSource);
+        }).then(function (slug) {
+            // no source suffixes present
+            if (slug === null) {
+                return false;
+            }
+
+            slugValue = slug;
+
+            // determine if the suffixed slug is unique
+            return checkSlug(slug);
+        }).then(function (isUnique) {
+            // go ahead and return the unique suffixed slug
+            if (isUnique) {
+                return slugValue;
+            }
+
+            // add on numeric prefixes (i.e., "-1", "-2") until the slug is unique
+            return addNumericSuffix(slugValue);
+        }).then(function (slug) {
+            // update the slug
+            instance.slug = slug;
+
+            return next(null, instance);
         });
     };
 

--- a/lib/sequelize-slugify.js
+++ b/lib/sequelize-slugify.js
@@ -82,7 +82,7 @@ SequelizeSlugify.prototype.slugifyModel = function (Model, slugOptions) {
                     return suffixedSlug;
                 }
 
-                return suffixHelper(slug, count++);
+                return suffixHelper(slug, count + 1);
             });
         })(slugValue, 1);
     };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.2.2",
     "lodash": "^3.10.1",
     "slug": "^0.9.1"
   },

--- a/test/tests.js
+++ b/test/tests.js
@@ -16,8 +16,8 @@ var sequelize = new Sequelize('sequelize_slugify_test', dbUsername, dbPassword, 
 });
 
 var SequelizeSlugify = require('../index');
-var chai = require("chai");
-var chaiAsPromised = require("chai-as-promised");
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 var expect = chai.expect;
 
@@ -34,12 +34,21 @@ var GetUser = function(modelname) {
         familyName: {
             type: Sequelize.STRING,
             allowNull: false
+        },
+        nickName: {
+            type: Sequelize.STRING,
+            allowNull: true
+        },
+        age: {
+            type: Sequelize.INTEGER,
+            allowNull: true
         }
     });
 };
 
 var User = {};
 var userId = 0;
+
 describe('sequelize-slugify', function () {
 
     describe('slugs', function () {
@@ -48,55 +57,119 @@ describe('sequelize-slugify', function () {
         beforeEach(function () {
             User = GetUser('user' + userId);
             userId++;
-            return sequelize.sync({force: true});
+
+            return sequelize.sync({ force: true });
         });
 
         it('should create a slug from a single field', function () {
             SequelizeSlugify.slugifyModel(User, {
                 source: ['givenName']
             });
-            return User.create({givenName: 'Suzan', familyName: 'Scheiber'})
-                .then(function (user) {
-                    return expect(user.slug).to.equal('suzan');
-                });
+
+            return User.create({
+                givenName: 'Suzan',
+                familyName: 'Scheiber'
+            }).then(function (user) {
+                return expect(user.slug).to.equal('suzan');
+            });
         });
 
         it('should create a slug from multiple fields', function () {
             SequelizeSlugify.slugifyModel(User, {
                 source: ['givenName', 'familyName']
             });
-            return User.create({givenName: 'Ernesto', familyName: 'Elsass'})
-                .then(function (user) {
-                    return expect(user.slug).to.equal('ernesto-elsass');
+
+            return User.create({
+                givenName: 'Ernesto',
+                familyName: 'Elsass'
+            }).then(function (user) {
+                return expect(user.slug).to.equal('ernesto-elsass');
+            });
+        });
+
+        describe('source suffixes', function () {
+            it('should use provided slug suffixes if the slug already exists', function () {
+                SequelizeSlugify.slugifyModel(User, {
+                    source: ['givenName', 'familyName'],
+                    suffixSource: ['nickName']
                 });
+
+                return User.create({
+                    givenName: 'Cleora',
+                    familyName: 'Curley'
+                }).then(function () {
+                    return User.create({
+                        givenName: 'Cleora',
+                        familyName: 'Curley',
+                        nickName: 'Cleo'
+                    });
+                }).then(function(user) {
+                    return expect(user.slug).to.equal('cleora-curley-cleo');
+                });
+            });
+
+            it('should handle multiple slug suffix fields', function () {
+                SequelizeSlugify.slugifyModel(User, {
+                    source: ['givenName', 'familyName'],
+                    suffixSource: ['nickName', 'age']
+                });
+
+                return User.create({
+                    givenName: 'Donald',
+                    familyName: 'Draper'
+                }).then(function () {
+                    return User.create({
+                        givenName: 'Donald',
+                        familyName: 'Draper',
+                        nickName: 'Don'
+                    });
+                }).then(function () {
+                    return User.create({
+                        givenName: 'Donald',
+                        familyName: 'Draper',
+                        nickName: 'Don',
+                        age: 42
+                    });
+                }).then(function(user) {
+                    return expect(user.slug).to.equal('donald-draper-don-42');
+                });
+            });
         });
 
         it('should increment slug suffix if it already exists', function () {
             SequelizeSlugify.slugifyModel(User, {
                 source: ['givenName', 'familyName']
             });
-            return User.create({givenName: 'Cleora', familyName: 'Curley'})
-                .then(function () {
-                    return User.create({givenName: 'Cleora', familyName: 'Curley'})
-                        .then(function(user) {
-                            return expect(user.slug).to.equal('cleora-curley-1');
-                        });
+
+            return User.create({
+                givenName: 'Cleora',
+                familyName: 'Curley'
+            }).then(function () {
+                return User.create({
+                    givenName: 'Cleora',
+                    familyName: 'Curley'
                 });
+            }).then(function(user) {
+                return expect(user.slug).to.equal('cleora-curley-1');
+            });
         });
 
         it('should overwrite slug by default', function () {
             SequelizeSlugify.slugifyModel(User, {
                 source: ['givenName']
             });
-            return User.create({givenName: 'Rupert', familyName: 'Rinaldi'})
-                .then(function (user) {
-                    user.givenName = 'Genie';
-                    user.familyName = 'Gayden';
-                    return user.save()
-                        .then(function(updatedUser) {
-                            return expect(updatedUser.slug).to.equal('genie');
-                        });
-                });
+
+            return User.create({
+                givenName: 'Rupert',
+                familyName: 'Rinaldi'
+            }).then(function (user) {
+                user.givenName = 'Genie';
+                user.familyName = 'Gayden';
+
+                return user.save();
+            }).then(function(updatedUser) {
+                return expect(updatedUser.slug).to.equal('genie');
+            });
         });
 
         it('should NOT overwrite slug if option says not to', function () {
@@ -104,15 +177,18 @@ describe('sequelize-slugify', function () {
                 source: ['givenName'],
                 overwrite: false
             });
-            return User.create({givenName: 'Miquel', familyName: 'Mceachin'})
-                .then(function (user) {
-                    user.givenName = 'Sallie';
-                    user.familyName = 'Shira';
-                    return user.save()
-                        .then(function(updatedUser) {
-                            return expect(updatedUser.slug).to.equal('miquel');
-                        });
-                });
+
+            return User.create({
+                givenName: 'Miquel',
+                familyName: 'Mceachin'
+            }).then(function (user) {
+                user.givenName = 'Sallie';
+                user.familyName = 'Shira';
+
+                return user.save();
+            }).then(function(updatedUser) {
+                return expect(updatedUser.slug).to.equal('miquel');
+            });
         });
     });
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -134,6 +134,39 @@ describe('sequelize-slugify', function () {
                     return expect(user.slug).to.equal('donald-draper-don-42');
                 });
             });
+
+            it('should fall back on numeric suffixes', function() {
+                SequelizeSlugify.slugifyModel(User, {
+                    source: ['givenName', 'familyName'],
+                    suffixSource: ['nickName', 'age']
+                });
+
+                return User.create({
+                    givenName: 'Gary',
+                    familyName: 'Gray',
+                    nickName: 'Gutsy'
+                }).then(function () {
+                    return User.create({
+                        givenName: 'Gary',
+                        familyName: 'Gray',
+                        nickName: 'Gutsy'
+                    });
+                }).then(function () {
+                    return User.create({
+                        givenName: 'Gary',
+                        familyName: 'Gray',
+                        nickName: 'Gutsy'
+                    });
+                }).then(function () {
+                    return User.create({
+                        givenName: 'Gary',
+                        familyName: 'Gray',
+                        nickName: 'Gutsy'
+                    });
+                }).then(function(user) {
+                    return expect(user.slug).to.equal('gary-gray-gutsy-2');
+                });
+            });
         });
 
         it('should increment slug suffix if it already exists', function () {


### PR DESCRIPTION
This implements the behavior I suggested in #4.

It draws from the `suffixSource` option to generate suffixes that will make the slug unique, before defaulting to appending a numeric suffix. It will attempt to use as few of the source suffixes as possible in order to make the slug unique.

It required a bit of a rewrite to get it to work properly, hence the pretty extensive diff.

Let me know if you have any questions/comments.

Cheers!