### PR TITLE
Check if next callback exists before calling

### DIFF
--- a/lib/sequelize-slugify.js
+++ b/lib/sequelize-slugify.js
@@ -142,7 +142,7 @@ SequelizeSlugify.prototype.slugifyModel = function (Model, slugOptions) {
             // update the slug
             instance.slug = slug;
 
-            return next(null, instance);
+            return next ? next(null, instance) : instance;
         });
     };
 

--- a/lib/sequelize-slugify.js
+++ b/lib/sequelize-slugify.js
@@ -108,7 +108,7 @@ SequelizeSlugify.prototype.slugifyModel = function (Model, slugOptions) {
         } else {
             instance.slug = slugValue;
 
-            return next(null, instance);
+            return next ? next(null, instance) : instance;
         }
 
         // determine if the slug is unique


### PR DESCRIPTION
Sequelize v4 no longer supports callbacks and thus no longer provides a callback to execute, per sequelize/sequelize#7792