### PR TITLE
Allow passing of parsing options to slug module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ slugifyModel takes an options object as it's second parameter.
 ```javascript
 SequelizeSlugify.slugifyModel(User, {
     source: ['givenName'],
-    overwrite: false
+    overwrite: false,
+    slugOptions: { lower: true },
 });
 ```
 Available Options
@@ -35,6 +36,7 @@ Available Options
 - `source` - (Required) Array of field names in the model to build the slug from
 - `suffixSource` - (Optional) Array of field names in the model to use as the source for additional suffixes to make the slug unique (before defaulting to adding numbers to the end of the slug).
 - `overwrite` = (Default TRUE) Change the slug if the source fields change once the slug has already been built
+- `slugOptions` = (Default `{ lower: true}`) Pass additional options for slug generation as defined by [`slug`](https://github.com/dodo/node-slug).
 
 ## Usage Examples
 

--- a/lib/sequelize-slugify.js
+++ b/lib/sequelize-slugify.js
@@ -18,7 +18,8 @@ SequelizeSlugify.prototype.slugifyModel = function (Model, slugOptions) {
             return instance[slugSourceField];
         });
 
-        return slug(slugParts.join(' '), { lower: true });
+        var options = (slugOptions && slugOptions.slugOptions) || { lower: true};
+        return slug(slugParts.join(' '), options);
     };
 
     /**


### PR DESCRIPTION
`slug` allows for parsing of options, and thus `sequelize-slugify` should be able to pass user-defined options through to `slug`.