### PR TITLE
Add paranoid option for duplicate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ SequelizeSlugify.slugifyModel(User, {
     overwrite: false,
     column: 'slug',
     incrementalSeparator: '-',
-    passTransaction: true
+    passTransaction: true,
+    paranoid: true
 });
 ```
 Available Options
@@ -51,6 +52,7 @@ Available Options
 - `column` - (Optional)(Default `slug`) Specify which column the slug is to be stored into in the model.
 - `incrementalSeparator` - (Optional)(Default `-`) Specify the separator between the slug, and the duplicate count.
 - `passTransaction` - (Optional)(Default `true`) Whether to pass an outer transaction, if one exists, to the plugin.
+- `paranoid` - (Optional)(Default `true`) Whether the duplication check will use a paranoid query or not, for determining the next unique slug.
 
 ## Methods
 

--- a/lib/sequelize-slugify.js
+++ b/lib/sequelize-slugify.js
@@ -17,7 +17,8 @@ class SequelizeSlugify {
       overwrite: true,
       column: 'slug',
       incrementalSeparator: '-',
-      passTransaction: true
+      passTransaction: true,
+      paranoid: true
     };
 
     const slugifyOptions = {...DEFAULT_OPTIONS, ...options};
@@ -95,7 +96,8 @@ class SequelizeSlugify {
     const isUniqueSlug = async function (slug, transaction) {
       const result = await model.findOne({
         where: {[slugColumn]: slug },
-        transaction: transaction
+        transaction: transaction,
+        paranoid: options.paranoid
       });
       return result === null;
     };


### PR DESCRIPTION
### Description
Adds a paranoid option for the slug duplication check. Currently the duplication check query defaults to `paranoid: true`, which can be problematic if there is a soft deleted row that contains the slug to be generated. This will result in a validation error on any column with a unique constraint, or create a duplicate slug (though on a non soft-deleted row) for columns without a unique constraint.

I think in an ideal world, the default of paranoid would be derived from the model's paranoid, however that would be a breaking change, so leaving that for now.

### Checklist
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
